### PR TITLE
Fix wifi power save mode

### DIFF
--- a/setup/services/create_services.sh
+++ b/setup/services/create_services.sh
@@ -39,4 +39,4 @@ sudo dpkg -i setup/services/usbmount.deb
 sudo cp setup/services/wifi_check.sh /etc/wpa_supplicant/
 
 # Copy wlan0.conf to prevent wifi power save mode
-sudo cp wlan0.conf /etc/network/interfaces.d/
+sudo cp setup/services/wlan0.conf /etc/network/interfaces.d/

--- a/setup/services/create_services.sh
+++ b/setup/services/create_services.sh
@@ -37,3 +37,6 @@ sudo dpkg -i setup/services/usbmount.deb
 
 # Copy wifi_check script
 sudo cp setup/services/wifi_check.sh /etc/wpa_supplicant/
+
+# Copy wlan0.conf to prevent wifi power save mode
+sudo cp wlan0.conf /etc/network/interfaces.d/

--- a/setup/services/wlan0.conf
+++ b/setup/services/wlan0.conf
@@ -1,0 +1,5 @@
+auto lo
+
+auto wlan0
+iface wlan0 inet dhcp
+ post-up iwconfig wlan0 power off


### PR DESCRIPTION
Wifi power save gets enabled before network gets a chance to stabilize, causing the wifi_check script to default to hotspot mode almost every time.